### PR TITLE
link to build logs of origin for subpackages

### DIFF
--- a/app.py
+++ b/app.py
@@ -508,7 +508,8 @@ def package(branch, repo, arch, name):
                                                          origin=package['origin'])
 
     build_url = config.get('external', 'build-log').format(commit=git_commit, branch=branch, repo=repo, arch=arch,
-                                                           name=name, version=package['version'],
+                                                           name=package['origin'] if package['origin'] is not None else name,
+                                                           version=package['version'],
                                                            buildbot_version=package['version'].replace('.', '_'),
                                                            origin=package['origin'])
 


### PR DESCRIPTION
Build logs for subpackages like [1] don't work so link to the origin [2]

[1] https://build.chimera-linux.org/#/builders/builder-riscv64/builds/*/steps/build_packages/logs/pkg_main_base-python3.11_3_11_4-r1
[2] https://build.chimera-linux.org/#/builders/builder-riscv64/builds/*/steps/build_packages/logs/pkg_main_python_3_11_4-r1

While the logic is sound in my head this is fully untested as I don't have a clue how to try this locally, so marking as a draft for now.